### PR TITLE
Allow 'firstWrite' to be passed in as 'mode'

### DIFF
--- a/lib/csv-stringifiers/object.js
+++ b/lib/csv-stringifiers/object.js
@@ -15,8 +15,7 @@ class ObjectCsvStringifier extends AbstractCsvStringifier {
         if (!isHeaderAvailable) return null;
 
         return this._header.reduce((memo, field) =>
-            Object.assign({}, memo, {[field.id]: field.title}), {}
-        );
+            Object.assign({}, memo, {[field.id]: field.title}), {});
     }
 
     _getRecordAsArray(record) {

--- a/lib/csv-writer-factory.js
+++ b/lib/csv-writer-factory.js
@@ -18,7 +18,8 @@ class CsvWriterFactory {
             csvStringifier,
             encoding: params.encoding,
             fs,
-            path: params.path
+            path: params.path,
+            append: params.append
         });
     }
 
@@ -30,7 +31,8 @@ class CsvWriterFactory {
             csvStringifier,
             encoding: params.encoding,
             fs,
-            path: params.path
+            path: params.path,
+            append: params.append
         });
     }
 

--- a/lib/csv-writer.js
+++ b/lib/csv-writer.js
@@ -6,21 +6,25 @@ const DEFAULT_ENCODING = 'utf8';
 class CsvWriter {
 
     constructor(params) {
-        this._fs = params.fs;
-        this._path = params.path;
-        this._encoding = params.encoding;
-        this._csvStringifier = params.csvStringifier;
-
-        this._firstWrite = true;
+        const defaults = {
+            encoding: DEFAULT_ENCODING,
+            append: false
+        };
+        const _params = Object.assign(defaults, params);
+        this._fs = _params.fs;
+        this._path = _params.path;
+        this._csvStringifier = _params.csvStringifier;
+        this._encoding = _params.encoding;
+        this._append = _params.append;
     }
 
     writeRecords(records) {
-        const headerString = this._firstWrite && this._csvStringifier.getHeaderString();
+        const headerString = !this._append && this._csvStringifier.getHeaderString();
         const recordsString = this._csvStringifier.stringifyRecords(records);
         const writeString = (headerString || '') + recordsString;
         const option = this._getWriteOption();
         return this._write(writeString, option)
-            .then(() => { this._firstWrite = false; });
+            .then(() => { this._append = true; });
     }
 
     _write(string, options) {
@@ -34,8 +38,8 @@ class CsvWriter {
 
     _getWriteOption() {
         return {
-            encoding: this._encoding || DEFAULT_ENCODING,
-            flag: this._firstWrite ? 'w' : 'a'
+            encoding: this._encoding,
+            flag: this._append ? 'a' : 'w'
         };
     }
 

--- a/test/lib/csv-writer.test.js
+++ b/test/lib/csv-writer.test.js
@@ -79,6 +79,58 @@ describe('CsvWriter', () => {
             });
     });
 
+    it('opens a file in append mode on the first write if \'a\' is specified as the initial mode', () => {
+        const fs = {writeFile: sinon.stub().callsArgWith(3, null)};
+        const arrayCsvStringifier = {
+            getHeaderString: () => 'HEADER_STRING',
+            stringifyRecords: () => 'CSV_STRING'
+        };
+        const writer = new CsvWriter({
+            fs,
+            encoding: 'ENCODING',
+            csvStringifier: arrayCsvStringifier,
+            path: 'FILE_PATH',
+            append: true
+        });
+
+        return writer.writeRecords('RECORDS').then(() => {
+            expect(fs.writeFile.args[0].slice(0, 3)).to.eql([
+                'FILE_PATH',
+                'CSV_STRING',
+                {
+                    encoding: 'ENCODING',
+                    flag: 'a'
+                }
+            ]);
+        });
+    });
+
+    it('opens a file in write mode if \'w\' is specified as the initial mode', () => {
+        const fs = {writeFile: sinon.stub().callsArgWith(3, null)};
+        const arrayCsvStringifier = {
+            getHeaderString: () => 'HEADER_STRING',
+            stringifyRecords: () => 'RECORDS_STRING'
+        };
+        const writer = new CsvWriter({
+            fs,
+            encoding: 'ENCODING',
+            csvStringifier: arrayCsvStringifier,
+            path: 'FILE_PATH',
+            append: false
+        });
+
+        return writer.writeRecords('RECORDS').then(() => {
+            expect(fs.writeFile.args[0].slice(0, 3)).to.eql([
+                'FILE_PATH',
+                'HEADER_STRINGRECORDS_STRING',
+                {
+                    encoding: 'ENCODING',
+                    flag: 'w'
+                }
+            ]);
+        });
+    });
+
     it('writes to a file with the specified encoding', () => {
         const fs = {writeFile: sinon.stub().callsArgWith(3, null)};
         const arrayCsvStringifier = {


### PR DESCRIPTION
I have a use-case where it's useful to specify whether I am wanting to append to an already existing file on the first write.

This replaces _firstWrite with _mode, some validation to ensure that it defaults to 'w' if not passed in, otherwise it is 'w' or 'a'.

Added a couple unit tests for the new functionality, this shouldn't break the existing interface(s).