### PR TITLE
Records list now accepts any iterable, not only an array

### DIFF
--- a/lib/csv-stringifiers/abstract.js
+++ b/lib/csv-stringifiers/abstract.js
@@ -16,10 +16,12 @@ class AbstractCsvStringifier {
     }
 
     stringifyRecords(records) {
-        const csvLines = records
-            .map(record => this._getRecordAsArray(record))
-            .map(record => this._getCsvLine(record));
-        return csvLines.join(RECORD_DELIMITER) + RECORD_DELIMITER;
+        let output = "";
+        for(let record of records){
+            output += this._getCsvLine(this._getRecordAsArray(record));
+            output += RECORD_DELIMITER;
+        }
+        return output;
     }
 
     /* istanbul ignore next */_getRecordAsArray(_record) {

--- a/lib/csv-stringifiers/abstract.js
+++ b/lib/csv-stringifiers/abstract.js
@@ -16,12 +16,12 @@ class AbstractCsvStringifier {
     }
 
     stringifyRecords(records) {
-        let output = '';
+        const array = [];
         for (let record of records) {
-            output += this._getCsvLine(this._getRecordAsArray(record));
-            output += RECORD_DELIMITER;
+            array.push(this._getCsvLine(this._getRecordAsArray(record)));
         }
-        return output;
+        array.push('');
+        return array.join(RECORD_DELIMITER);
     }
 
     /* istanbul ignore next */_getRecordAsArray(_record) {

--- a/lib/csv-stringifiers/abstract.js
+++ b/lib/csv-stringifiers/abstract.js
@@ -16,8 +16,8 @@ class AbstractCsvStringifier {
     }
 
     stringifyRecords(records) {
-        let output = "";
-        for(let record of records){
+        let output = '';
+        for (let record of records) {
             output += this._getCsvLine(this._getRecordAsArray(record));
             output += RECORD_DELIMITER;
         }

--- a/test/unit/csv-stringifiers/array.test.js
+++ b/test/unit/csv-stringifiers/array.test.js
@@ -19,6 +19,22 @@ describe('ArrayCsvStringifier', () => {
             });
         });
     });
+    
+    describe('When records input is an iterable other than an array', () => {
+        it('behaves the same as when the input was an array', () => {
+            const stringifier = createArrayCsvStringifier({
+                header: ['TITLE_A', 'TITLE_B']
+            });
+            function* recordGenerator(){
+                yield records[0];
+                yield records[1];
+            }
+            const recordArray = Array.from(recordGenerator());
+            const generatorOutput = stringifier.stringifyRecords(recordGenerator());
+            const arrayOutput = stringifier.stringifyRecords(recordArray);
+            assert.equal(generatorOutput, arrayOutput);
+        });
+    });
 
     function generateTestCases(fieldDelimiter) {
         const delim = resolveDelimiterChar(fieldDelimiter);

--- a/test/unit/csv-stringifiers/array.test.js
+++ b/test/unit/csv-stringifiers/array.test.js
@@ -19,13 +19,13 @@ describe('ArrayCsvStringifier', () => {
             });
         });
     });
-    
+
     describe('When records input is an iterable other than an array', () => {
         it('behaves the same as when the input was an array', () => {
             const stringifier = createArrayCsvStringifier({
                 header: ['TITLE_A', 'TITLE_B']
             });
-            function* recordGenerator(){
+            function * recordGenerator() {
                 yield records[0];
                 yield records[1];
             }

--- a/test/unit/csv-stringifiers/object.test.js
+++ b/test/unit/csv-stringifiers/object.test.js
@@ -22,6 +22,22 @@ describe('ObjectCsvStringifier', () => {
             });
         });
     });
+    
+    describe('When records input is an iterable other than an array', () => {
+        it('behaves the same as when the input was an array', () => {
+            const stringifier = createObjectCsvStringifier({
+                header: ['TITLE_A', 'TITLE_B']
+            });
+            function* recordGenerator(){
+                yield records[0];
+                yield records[1];
+            }
+            const recordArray = Array.from(recordGenerator());
+            const generatorOutput = stringifier.stringifyRecords(recordGenerator());
+            const arrayOutput = stringifier.stringifyRecords(recordArray);
+            assert.equal(generatorOutput, arrayOutput);
+        });
+    });
 
     function generateTestCases(fieldDelimiter) {
         const delim = resolveDelimiterChar(fieldDelimiter);

--- a/test/unit/csv-stringifiers/object.test.js
+++ b/test/unit/csv-stringifiers/object.test.js
@@ -22,13 +22,13 @@ describe('ObjectCsvStringifier', () => {
             });
         });
     });
-    
+
     describe('When records input is an iterable other than an array', () => {
         it('behaves the same as when the input was an array', () => {
             const stringifier = createObjectCsvStringifier({
                 header: ['TITLE_A', 'TITLE_B']
             });
-            function* recordGenerator(){
+            function * recordGenerator() {
                 yield records[0];
                 yield records[1];
             }


### PR DESCRIPTION
Previously there were several calls to `input.map` in `AbstractCsvStringifier.stringifyRecords`, which works for arrays but not for generators or most other iterable objects. The code has been changed to use a `for(x of y)` loop instead of `map` functions.

Also added two new unit tests to verify this behavior.

As a side-effect, the new code is also more performant and memory-efficient! (edit: Probably? I haven't actually benchmarked. Depends on how string concatenation compares to building an array and then calling join, I guess)