### PR TITLE
Fix for "Can't resolve 'fs'"

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
     "ts-node": "^9.0.0",
     "tslint": "^6.1.3",
     "typescript": "^4.0.5"
+  },
+  "browser": {
+    "fs": false,
+    "path": false,
+    "os": false
   }
 }


### PR DESCRIPTION
Added "browser" section to package.json so that csv-writer continues to work with latest version of React/node/npm