### PR TITLE
adds optional parameter quoteEmptyFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ console.log(csvStringifier.stringifyRecords(records));
 
       Default: `false`. Set it to `true` to double-quote all fields regardless of their values.
 
+  * quoteEmptyFields `<boolean>` (optional)
+
+      Default: `false`. Set it to `true` to double-quote ("") fields with empty values (not set, undefined, null).
+
   * encoding `<string>` (optional)
 
       Default: `utf8`.
@@ -190,6 +194,10 @@ console.log(csvStringifier.stringifyRecords(records));
   * alwaysQuote `<boolean>` (optional)
 
       Default: `false`. Set it to `true` to double-quote all fields regardless of their values.
+
+  * quoteEmptyFields `<boolean>` (optional)
+
+      Default: `false`. Set it to `true` to double-quote ("") fields with empty values (not set, undefined, null).
 
   * encoding `<string>` (optional)
 
@@ -246,6 +254,11 @@ console.log(csvStringifier.stringifyRecords(records));
 
       Default: `false`. Set it to `true` to double-quote all fields regardless of their values.
 
+ * quoteEmptyFields `<boolean>` (optional)
+
+      Default: `false`. Set it to `true` to double-quote ("") fields with empty values (not set, undefined, null).
+
+
 ##### Returns:
 
 * `<ObjectCsvStringifier>`
@@ -286,6 +299,11 @@ console.log(csvStringifier.stringifyRecords(records));
   * alwaysQuote `<boolean>` (optional)
 
       Default: `false`. Set it to `true` to double-quote all fields regardless of their values.
+
+  * quoteEmptyFields `<boolean>` (optional)
+
+      Default: `false`. Set it to `true` to double-quote ("") fields with empty values (not set, undefined, null).
+
 
 ##### Returns:
 

--- a/src/lib/csv-stringifier-factory.ts
+++ b/src/lib/csv-stringifier-factory.ts
@@ -8,6 +8,7 @@ export interface ArrayCsvStringifierParams {
     fieldDelimiter?: string
     recordDelimiter?: string
     alwaysQuote?: boolean
+    quoteEmptyFields?: boolean
 }
 
 export interface ObjectCsvStringifierParams {
@@ -16,17 +17,18 @@ export interface ObjectCsvStringifierParams {
     recordDelimiter?: string
     headerIdDelimiter?: string
     alwaysQuote?: boolean
+    quoteEmptyFields?:boolean
 }
 
 export class CsvStringifierFactory {
 
     createArrayCsvStringifier(params: ArrayCsvStringifierParams) {
-        const fieldStringifier = createFieldStringifier(params.fieldDelimiter, params.alwaysQuote)
+        const fieldStringifier = createFieldStringifier(params.fieldDelimiter, params.alwaysQuote, params.quoteEmptyFields)
         return new ArrayCsvStringifier(fieldStringifier, params.recordDelimiter, params.header)
     }
 
     createObjectCsvStringifier(params: ObjectCsvStringifierParams) {
-        const fieldStringifier = createFieldStringifier(params.fieldDelimiter, params.alwaysQuote)
+        const fieldStringifier = createFieldStringifier(params.fieldDelimiter, params.alwaysQuote, params.quoteEmptyFields)
         return new ObjectCsvStringifier(fieldStringifier, params.header, params.recordDelimiter, params.headerIdDelimiter)
     }
 

--- a/src/lib/csv-writer-factory.ts
+++ b/src/lib/csv-writer-factory.ts
@@ -10,6 +10,7 @@ export interface ArrayCsvWriterParams {
     alwaysQuote?: boolean
     encoding?: string
     append?: boolean
+    quoteEmptyFields?: boolean
 }
 
 export interface ObjectCsvWriterParams {
@@ -21,6 +22,7 @@ export interface ObjectCsvWriterParams {
     alwaysQuote?: boolean
     encoding?: string
     append?: boolean
+    quoteEmptyFields?: boolean
 }
 
 export class CsvWriterFactory {
@@ -31,7 +33,8 @@ export class CsvWriterFactory {
             header: params.header,
             fieldDelimiter: params.fieldDelimiter,
             recordDelimiter: params.recordDelimiter,
-            alwaysQuote: params.alwaysQuote
+            alwaysQuote: params.alwaysQuote,
+            quoteEmptyFields: params.quoteEmptyFields
         })
         return new CsvWriter(csvStringifier, params.path, params.encoding, params.append)
     }
@@ -42,7 +45,8 @@ export class CsvWriterFactory {
             fieldDelimiter: params.fieldDelimiter,
             recordDelimiter: params.recordDelimiter,
             headerIdDelimiter: params.headerIdDelimiter,
-            alwaysQuote: params.alwaysQuote
+            alwaysQuote: params.alwaysQuote,
+            quoteEmptyFields: params.quoteEmptyFields
         })
         return new CsvWriter(csvStringifier, params.path, params.encoding, params.append)
     }

--- a/src/lib/field-stringifier.ts
+++ b/src/lib/field-stringifier.ts
@@ -4,7 +4,7 @@ const DEFAULT_FIELD_DELIMITER = ','
 const VALID_FIELD_DELIMITERS = [DEFAULT_FIELD_DELIMITER, ';']
 
 export abstract class FieldStringifier {
-    constructor(public readonly fieldDelimiter: string) {}
+    constructor(public readonly fieldDelimiter: string, public readonly quoteEmptyFields: boolean) {}
 
     abstract stringify(value?: Field): string
 
@@ -19,7 +19,10 @@ export abstract class FieldStringifier {
 
 class DefaultFieldStringifier extends FieldStringifier {
     stringify(value?: Field): string {
-        if (this.isEmpty(value)) return ''
+        if (this.isEmpty(value)) {
+            if(this.quoteEmptyFields) return '""'
+            return ''
+        }
         const str = String(value)
         return this.needsQuote(str) ? this.quoteField(str) : str
     }
@@ -31,13 +34,17 @@ class DefaultFieldStringifier extends FieldStringifier {
 
 class ForceQuoteFieldStringifier extends FieldStringifier {
     stringify(value?: Field): string {
-        return this.isEmpty(value) ? '' : this.quoteField(String(value))
+        if (this.isEmpty(value)) {
+            if (this.quoteEmptyFields) return '""'
+            return ''
+        }
+        return this.quoteField(String(value))
     }
 }
 
-export function createFieldStringifier(fieldDelimiter: string = DEFAULT_FIELD_DELIMITER, alwaysQuote = false) {
+export function createFieldStringifier(fieldDelimiter: string = DEFAULT_FIELD_DELIMITER, alwaysQuote = false, quoteEmptyFields = false) {
     _validateFieldDelimiter(fieldDelimiter)
-    return alwaysQuote ? new ForceQuoteFieldStringifier(fieldDelimiter) : new DefaultFieldStringifier(fieldDelimiter)
+    return alwaysQuote ? new ForceQuoteFieldStringifier(fieldDelimiter, quoteEmptyFields) : new DefaultFieldStringifier(fieldDelimiter, quoteEmptyFields)
 }
 
 function _validateFieldDelimiter(delimiter: string): void {

--- a/src/test/csv-stringifiers/array.test.ts
+++ b/src/test/csv-stringifiers/array.test.ts
@@ -8,6 +8,12 @@ describe('ArrayCsvStringifier', () => {
         ['VALUE_A2', 'VALUE_B2']
     ]
 
+    const recordsWithEmpty = [
+        ...records,
+        ['VALUE_A3', undefined],
+        [null, 'VALUE_B4']
+    ]
+
     describe('When field delimiter is comma', generateTestCases(','))
 
     describe('When field delimiter is semicolon', generateTestCases(';'))
@@ -57,6 +63,29 @@ describe('ArrayCsvStringifier', () => {
 
         it('quotes all data fields', () => {
             strictEqual(stringifier.stringifyRecords(records), '"VALUE_A1","VALUE_B1"\n"VALUE_A2","VALUE_B2"\n')
+        })
+    })
+
+    describe('When `quoteEmptyFields` flag is set', () => {
+        const stringifier = createArrayCsvStringifier({
+            header: ['TITLE_A', 'TITLE_B'],
+            quoteEmptyFields: true
+        })
+
+        it('quotes all empty fields', () => {
+            strictEqual(stringifier.stringifyRecords(recordsWithEmpty), 'VALUE_A1,VALUE_B1\nVALUE_A2,VALUE_B2\nVALUE_A3,""\n"",VALUE_B4\n')
+        })
+    })
+
+    describe('When `quoteEmptyFields` and `alwaysQuote` flag is set', () => {
+        const stringifier = createArrayCsvStringifier({
+            header: ['TITLE_A', 'TITLE_B'],
+            quoteEmptyFields: true,
+            alwaysQuote: true
+        })
+
+        it('quotes all empty fields', () => {
+            strictEqual(stringifier.stringifyRecords(recordsWithEmpty), '"VALUE_A1","VALUE_B1"\n"VALUE_A2","VALUE_B2"\n"VALUE_A3",""\n"","VALUE_B4"\n')
         })
     })
 

--- a/src/test/csv-stringifiers/object.test.ts
+++ b/src/test/csv-stringifiers/object.test.ts
@@ -8,6 +8,12 @@ describe('ObjectCsvStringifier', () => {
         {FIELD_A: 'VALUE_A2', FIELD_B: 'VALUE_B2', OTHERS: {FIELD_C: 'VALUE_C2'}}
     ]
 
+    const recordsWithEmpty = [
+        ...records,
+        {FIELD_A: 'VALUE_A3', FIELD_B: undefined},
+        {FIELD_A: null, FIELD_B: 'VALUE_B4'}
+    ]
+
     describe('When field delimiter is comma', generateTestCases(','))
 
     describe('When field delimiter is semicolon', generateTestCases(';'))
@@ -84,6 +90,43 @@ describe('ObjectCsvStringifier', () => {
 
         it('picks up a value in nested objects', () => {
             strictEqual(stringifier.stringifyRecords(records), 'VALUE_A1,\nVALUE_A2,VALUE_C2\n')
+        })
+    })
+
+    describe('When `quoteEmptyFields` flag is set', () => {
+        const stringifier = createObjectCsvStringifier({
+            header: [
+                {id: 'FIELD_A', title: 'TITLE_A'},
+                {id: 'FIELD_B', title: 'TITLE_B'}
+            ],
+            quoteEmptyFields: true
+        })
+
+        it('header fields stays as is', () => {
+            strictEqual(stringifier.getHeaderString(), 'TITLE_A,TITLE_B\n')
+        })
+
+        it('quotes all data fields', () => {
+            strictEqual(stringifier.stringifyRecords(recordsWithEmpty), 'VALUE_A1,VALUE_B1\nVALUE_A2,VALUE_B2\nVALUE_A3,""\n"",VALUE_B4\n')
+        })
+    })
+
+    describe('When `quoteEmptyFields` and `alwaysQuote` flag is set', () => {
+        const stringifier = createObjectCsvStringifier({
+            header: [
+                {id: 'FIELD_A', title: 'TITLE_A'},
+                {id: 'FIELD_B', title: 'TITLE_B'}
+            ],
+            alwaysQuote: true,
+            quoteEmptyFields: true
+        })
+
+        it('quotes all header fields', () => {
+            strictEqual(stringifier.getHeaderString(), '"TITLE_A","TITLE_B"\n')
+        })
+
+        it('quotes all data field including empties', () => {
+            strictEqual(stringifier.stringifyRecords(recordsWithEmpty), '"VALUE_A1","VALUE_B1"\n"VALUE_A2","VALUE_B2"\n"VALUE_A3",""\n"","VALUE_B4"\n')
         })
     })
 

--- a/src/test/write-array-records.test.ts
+++ b/src/test/write-array-records.test.ts
@@ -11,6 +11,11 @@ describe('Write array records into CSV', () => {
         ['Mary', 'English']
     ]
 
+    const recordsWithEmpty = [
+        ...records,
+        ["Jack", undefined],
+        [null, "German"]]
+
     describe('When only path is specified', () => {
         const filePath = makeFilePath('minimum')
         let writer: CsvWriter<string[]>
@@ -119,6 +124,37 @@ describe('Write array records into CSV', () => {
         it('quotes all fields', async () => {
             await writer.writeRecords(records)
             assertFile(filePath, '"NAME","LANGUAGE"\n"Bob","French"\n"Mary","English"\n')
+        })
+    })
+
+    describe('When `quoteEmptyFields` flag is set', () => {
+        const filePath = makeFilePath('quote-empty-fields')
+
+        const writer = createArrayCsvWriter({
+            path: filePath,
+            header: ['NAME', 'LANGUAGE'],
+            quoteEmptyFields: true
+        })
+
+        it('quotes all empty fields', async () => {
+            await writer.writeRecords(recordsWithEmpty)
+            assertFile(filePath, 'NAME,LANGUAGE\nBob,French\nMary,English\nJack,""\n"",German\n')
+        })
+    })
+
+    describe('When `quoteEmptyFields` and `alwaysQuote` flag is set', () => {
+        const filePath = makeFilePath('quote-empty-fields-and-always-quote')
+
+        const writer = createArrayCsvWriter({
+            path: filePath,
+            header: ['NAME', 'LANGUAGE'],
+            quoteEmptyFields: true,
+            alwaysQuote: true
+        })
+
+        it('quotes all fields including empties', async () => {
+            await writer.writeRecords(recordsWithEmpty)
+            assertFile(filePath, '"NAME","LANGUAGE"\n"Bob","French"\n"Mary","English"\n"Jack",""\n"","German"\n')
         })
     })
 })

--- a/src/test/write-object-records.test.ts
+++ b/src/test/write-object-records.test.ts
@@ -11,6 +11,12 @@ describe('Write object records into CSV', () => {
         {name: 'Bob', lang: 'French', address: {country: 'France'}},
         {name: 'Mary', lang: 'English'}
     ]
+    const recordsWithEmpty = [
+        ...records,
+        { name: 'Jack', lang: null },
+        { name: undefined, lang: 'German' },
+        { name: "Hank" }
+    ]
 
     describe('When only path and header ids are given', () => {
         const filePath = makeFilePath('minimum')
@@ -155,4 +161,34 @@ describe('Write object records into CSV', () => {
             assertFile(filePath, 'NAME,COUNTRY\nBob,France\nMary,\n')
         })
     })
+
+    describe('When `quoteEmptyFields` flag is set', () => {
+        const filePath = makeFilePath('quote-empty-field')
+        const writer = createObjectCsvWriter({
+            path: filePath,
+            header: [{id: 'name', title: 'NAME'}, {id: 'lang', title: 'LANGUAGE'}],
+            quoteEmptyFields: true
+        })
+
+        it('quotes all empty fields', async () => {
+            await writer.writeRecords(recordsWithEmpty)
+            assertFile(filePath, 'NAME,LANGUAGE\nBob,French\nMary,English\nJack,""\n"",German\nHank,""\n')
+        })
+    })
+
+    describe('When `quoteEmptyFields` and `alwaysQuote` flag is set', () => {
+        const filePath = makeFilePath('quote-empty-field')
+        const writer = createObjectCsvWriter({
+            path: filePath,
+            header: [{id: 'name', title: 'NAME'}, {id: 'lang', title: 'LANGUAGE'}],
+            quoteEmptyFields: true,
+            alwaysQuote: true
+        })
+
+        it('quotes all empty fields', async () => {
+            await writer.writeRecords(recordsWithEmpty)
+            assertFile(filePath, '"NAME","LANGUAGE"\n"Bob","French"\n"Mary","English"\n"Jack",""\n"","German"\n"Hank",""\n')
+        })
+    })
+
 })


### PR DESCRIPTION
This pull request takes the input stated in issue https://github.com/ryu1kn/csv-writer/issues/60

with this PR, `createObjectCsvWriter` and `createArrayCsvWriter` accepts the parameter `quoteEmptyFields`, and this will any cause empty (null/undefined) values to be given an empty double quote (`""`) 